### PR TITLE
Using count instead of maximum.

### DIFF
--- a/miniskirt.rb
+++ b/miniskirt.rb
@@ -26,9 +26,7 @@ class Miniskirt < Struct.new(:__klass__)
       (m = klass.is_a?(Class) ? klass : klass.to_s.classify.constantize).new do |r|
         attrs.symbolize_keys!.reverse_update(h).each do |k, v|
           r.send "#{k}=", case v when String # Sequence and interpolate.
-            v.sub(/%\d*d/) {|d| d % n ||= (
-              m.respond_to?(:maximum) ? m.maximum(:id) : m.max(:id)
-            ).to_i + 1} % attrs % n
+            v.sub(/%\d*d/) {|d| d % n ||= m.count + 1} % attrs % n
           when Proc then v.call(r) else v
           end
         end

--- a/miniskirt.rb
+++ b/miniskirt.rb
@@ -26,7 +26,7 @@ class Miniskirt < Struct.new(:__klass__)
       (m = klass.is_a?(Class) ? klass : klass.to_s.classify.constantize).new do |r|
         attrs.symbolize_keys!.reverse_update(h).each do |k, v|
           r.send "#{k}=", case v when String # Sequence and interpolate.
-            v.sub(/%\d*d/) {|d| d % n ||= m.count + 1} % attrs % n
+            v.sub(/%\d*d/) {|d| d % n ||= self.count! } % attrs % n
           when Proc then v.call(r) else v
           end
         end
@@ -35,6 +35,11 @@ class Miniskirt < Struct.new(:__klass__)
 
     def create name, attrs = {}
       build(name, attrs).tap { |record| record.save! }
+    end
+    
+    def count!
+      @@count ||= 0
+      @@count += 1
     end
   end
 

--- a/miniskirt_test.rb
+++ b/miniskirt_test.rb
@@ -87,9 +87,9 @@ class MiniskirtTest < Test::Unit::TestCase
 end
 
 class Mock
-  @@maximum = nil
-  def self.maximum(column)
-    @@maximum
+  @@count = nil
+  def self.count
+    @@count
   end
 
   def initialize
@@ -97,7 +97,7 @@ class Mock
   end
 
   def save!
-    @@maximum = @@maximum.to_i + 1 unless @saved
+    @@count = @@count.to_i + 1 unless @saved
     @saved = true
   end
 

--- a/miniskirt_test.rb
+++ b/miniskirt_test.rb
@@ -87,17 +87,11 @@ class MiniskirtTest < Test::Unit::TestCase
 end
 
 class Mock
-  @@count = nil
-  def self.count
-    @@count
-  end
-
   def initialize
     yield self
   end
 
   def save!
-    @@count = @@count.to_i + 1 unless @saved
     @saved = true
   end
 


### PR DESCRIPTION
Changed to count instead of maximum to get the next sequence number. Makes more sense, and is fail-safe. Should fix #6.
