### PR TITLE
Changed sequences to use :count instead of :maximum/:max. 

### DIFF
--- a/miniskirt.rb
+++ b/miniskirt.rb
@@ -26,9 +26,7 @@ class Miniskirt < Struct.new(:__klass__)
       (m = klass.is_a?(Class) ? klass : klass.to_s.classify.constantize).new do |r|
         attrs.symbolize_keys!.reverse_update(h).each do |k, v|
           r.send "#{k}=", case v when String # Sequence and interpolate.
-            v.sub(/%\d*d/) {|d| d % n ||= (
-              m.respond_to?(:maximum) ? m.maximum(:id) : m.max(:id)
-            ).to_i + 1} % attrs % n
+            v.sub(/%\d*d/) {|d| d % n ||= m.count + 1} % attrs % n
           when Proc then v.call(r) else v
           end
         end

--- a/miniskirt_test.rb
+++ b/miniskirt_test.rb
@@ -87,9 +87,9 @@ class MiniskirtTest < Test::Unit::TestCase
 end
 
 class Mock
-  @@maximum = nil
-  def self.maximum(column)
-    @@maximum
+  @@count = 0
+  def self.count
+    @@count
   end
 
   def initialize
@@ -97,7 +97,7 @@ class Mock
   end
 
   def save!
-    @@maximum = @@maximum.to_i + 1 unless @saved
+    @@count += 1 unless @saved
     @saved = true
   end
 


### PR DESCRIPTION
Calculating sequences based on the `count` method works better when using alternative ORMs like Mongoid, because they tend to use non-numeric ids for records.

Works with ActiveRecord, Mongoid, MongoWrapper and all other ORM's with support for the `count` method.
